### PR TITLE
Don't use external programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,16 @@ Clone this repository and cd into the repository folder, then make some binaries
 ```
 sudo apt-get update  # Repair things that that seem to be a little sick.
 sudo apt-get upgrade
-sudo apt-get install -f locales
-sudo locale-gen en_US en_US.UTF-8
-sudo dpkg-reconfigure locales    # Select "en_US" locales.
-sudo apt-get install gcc make  # Get the C compiler
+sudo apt-get install build-essentials
 
-sudo gcc -o on on.c  # Compile
-sudo gcc -o off off.c
-sudo chmod +s on  # Allow executables to run with root privilage
-sudo chmod +s off
+# Add i2c to groups for user chip
+sudo usermod -a -G i2c chip
+
 ```
-Install node.js, npm and dependecies for the project
+Install node.js and npm by following the instructions at https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions to get the most up to date LTS release.
+
+Then install the dependencies
 ```
-sudo apt-get install nodejs
-sudo apt-get install npm
 npm install
 ```
 And start the server

--- a/chipled.js
+++ b/chipled.js
@@ -4,8 +4,9 @@ var express     = require('express'),
     port        = 3700,
     bodyParser  = require('body-parser'),
     router      = express.Router(),
-    exec        = require('child_process').exec;
-
+    i2c         = require('i2c'),
+    address     = 0x34,
+    wire        = new i2c(address, {device: '/dev/i2c-0'});
 
 console.log('Node version: ' + process.version);
 
@@ -14,19 +15,19 @@ console.log('Node version: ' + process.version);
 app.use(bodyParser.json());       // to support JSON-encoded bodies
 app.use(bodyParser.urlencoded({   // to support URL-encoded bodies
   extended: true
-})); 
+}));
 
 router.get('/', function(req, res) {
-  res.json({ message: 'It works!' });   
+  res.json({ message: 'It works!' });
 });
 
 router.get('/on', function(req, res) {
-  exec("./on", function (error, stdout, stderr) {});
-  res.json({ led: 'on' });   
+  wire.writeBytes(0x93, [0x01], function(err) {});
+  res.json({ led: 'on' });
 });
 
 router.get('/off', function(req, res) {
-  exec("./off", function (error, stdout, stderr) {});
+  wire.writeBytes(0x93, [0x00], function(err) {});
   res.json({ led: 'off' });   
 });
 

--- a/off.c
+++ b/off.c
@@ -1,7 +1,0 @@
-#include <stdio.h>
-int main(int argc, char **argv)
-{
-  system("/usr/sbin/i2cset -f -y 0 0x34 0x93 0x0");
-  return 0;
-}
-

--- a/on.c
+++ b/on.c
@@ -1,6 +1,0 @@
-#include <stdio.h>
-int main(int argc, char **argv)
-{
-  system("/usr/sbin/i2cset -f -y 0 0x34 0x93 0x1");
-  return 0;
-}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,12 @@
   "dependencies": {
     "body-parser": "1.14.1",
     "express": "4.13.3",
-    "request": "^2.65.0"
+    "request": "^2.65.0",
+    "i2c": "0.2.3"
   },
-  "author": "Lars Englund <lars.englund@gmail.com> (http://en.gravatar.com/larsenglund)"
+  "author": "Lars Englund <lars.englund@gmail.com> (http://en.gravatar.com/larsenglund)",
+  "contributors": [{
+    "name": "Troy Dack",
+    "email": "troy@dack.com.au"
+  }],
 }


### PR DESCRIPTION
This branch doesn't need to use an external program to turn the LED on or off.  It uses a nodejs i2c module instead.

By adding the group **i2C** to the _chip_ user you don't need any setuid or other special permissions to access `/dev/i2c-0`.
